### PR TITLE
Fix JSON TypeError on dict key can now be a numpy type

### DIFF
--- a/codejail/custom_encoder.py
+++ b/codejail/custom_encoder.py
@@ -1,5 +1,4 @@
 import json
-import numpy as np
 
 
 class GlobalEncoder(json.JSONEncoder):
@@ -14,10 +13,12 @@ class GlobalEncoder(json.JSONEncoder):
 
 class NumpyEncoder(json.JSONEncoder):
     """ Custom encoder for numpy data types """
+
     def default(self, obj):
+        import numpy as np
         if isinstance(obj, (np.int_, np.intc, np.intp, np.int8,
-            np.int16, np.int32, np.int64, np.uint8,
-            np.uint16, np.uint32, np.uint64)):
+                            np.int16, np.int32, np.int64, np.uint8,
+                            np.uint16, np.uint32, np.uint64)):
             return int(obj)
         elif isinstance(obj, (np.float_, np.float16, np.float32, np.float64)):
             return float(obj)
@@ -27,6 +28,6 @@ class NumpyEncoder(json.JSONEncoder):
             return obj.tolist()
         elif isinstance(obj, (np.bool_)):
             return bool(obj)
-        elif isinstance(obj, (np.void)): 
+        elif isinstance(obj, (np.void)):
             return None
         return json.JSONEncoder.default(self, obj)

--- a/codejail/safe_exec.py
+++ b/codejail/safe_exec.py
@@ -194,11 +194,6 @@ def json_safe(d):
     """
     # pylint: disable=invalid-name
 
-    # six.binary_type is here because bytes are sometimes ok if they represent valid utf8
-    # so we consider them valid for now and try to decode them with decode_object.  If that
-    # doesn't work they'll get dropped later in the process.
-    ok_types = (type(None), int, float, six.binary_type, six.text_type, list, tuple, dict)
-
     def decode_object(obj):
         """
         Convert an object to a JSON serializable form by decoding all byte strings.
@@ -213,6 +208,9 @@ def json_safe(d):
         """
         if isinstance(obj, bytes):
             return obj.decode('utf-8')
+        if type(obj).__module__ == 'numpy':
+            from custom_encoder import NumpyEncoder
+            return NumpyEncoder().default(obj)
         if isinstance(obj, (list, tuple)):
             new_list = []
             for i in obj:
@@ -231,8 +229,6 @@ def json_safe(d):
     bad_keys = ("__builtins__",)
     jd = {}
     for k, v in six.iteritems(d):
-        if not isinstance(v, ok_types):
-            continue
         if k in bad_keys:
             continue
         try:


### PR DESCRIPTION
When we have a dictionnary with numpy.int format as key the system JSON converter was crashing. 
```
Traceback (most recent call last):
  File "jailed_code", line 70, in json_safe
    v = json.loads(json.dumps(decode_object(v), cls=GlobalEncoder, default=lambda o: repr(o)))
  File "/usr/local/lib/python3.8/json/__init__.py", line 234, in dumps
    return cls(
  File "/usr/local/lib/python3.8/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/local/lib/python3.8/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
TypeError: keys must be str, int, float, bool or None, not numpy.int64
```
So I added a check to make sure we handle this case.